### PR TITLE
Replace deprecated std::auto_ptr with std::unique_ptr.

### DIFF
--- a/include/LTBL/LightSystem.h
+++ b/include/LTBL/LightSystem.h
@@ -53,9 +53,9 @@ class LightSystem
 
   std::vector<Light*> lightsToPreBuild;
 
-  std::auto_ptr<qdt::QuadTree> lightTree;
-  std::auto_ptr<qdt::QuadTree> hullTree;
-  std::auto_ptr<qdt::QuadTree> emissiveTree;
+  std::unique_ptr<qdt::QuadTree> lightTree;
+  std::unique_ptr<qdt::QuadTree> hullTree;
+  std::unique_ptr<qdt::QuadTree> emissiveTree;
 
   sf::RenderTexture renderTexture;
   sf::RenderTexture lightTemp;


### PR DESCRIPTION
With C++11 `std::auto_ptr` is deprecated and shouldn't be used, since it can have unexpected side effects, due to missing move semantic.