### PR TITLE
Removed warnings during CMake compilation in Ubuntu 14.10.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,17 +7,23 @@ I am not the original author of this code. I modified it to use the CMake
 build sytem and SFML 2.X. This has only been tested on OS X 10.7 Mavericks,
 so please submit any issues you have compiling on other systems.
 
-## Compiling
+## Compiling and Installing
 Do an out of source build. Specifically:
 
     mkdir build && cd build
     cmake ..
     make
 
-You can then say `bin/sample` to run the sample. I recommend using `build/`
-as your out of source build directory, because it is already on the
-`.gitignore`.
+# Ubuntu
+To do an out of source build in Ubuntu, follow the steps below:
 
+    sudo apt-get install build-essential cmake libsdl2-dev libglew-dev
+    cd /path/to/source
+    mkdir build && cd build
+    cmake ..
+    make && sudo make install    
+
+NOTE: Only tested in Ubuntu 14.10.
 
 ## Installing
 `make install`

--- a/include/LTBL/QuadTreeNode.h
+++ b/include/LTBL/QuadTreeNode.h
@@ -50,8 +50,7 @@ class QuadTreeNode {
   void queryToDepth(const AABB &queryRegion, std::vector<QuadTreeOccupant*> &queryResult, int depth);
 
   void debugRender();
-
-  friend class QuadTreeNode;
+  
   friend class QuadTreeOccupant;
   friend class QuadTree;
 };

--- a/include/LTBL/QuadTreeOccupant.h
+++ b/include/LTBL/QuadTreeOccupant.h
@@ -34,8 +34,6 @@ struct AABB {
 
   // Render the AABB for debugging purposes
   void debugRender();
-
-  friend struct AABB;
 };
 
 class QuadTreeOccupant {


### PR DESCRIPTION
When doing a 'make' in CMake, the compiler usually produces warnings. I removed the warnings in this fork. I also updated the README.markdown so that others in the Ubuntu ecosystem will be able to compile the project in their system.