### PR TITLE
Fixed an error in README.markdown.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,30 +11,30 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/cmake_modules" ${CMAKE_MODULE_P
 
 # light uses C++11 features
 if(CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 # Make sure that the runtime library gets link statically
 if(LIGHT_STATIC_STD_LIBS)
-	if(NOT SFML_STATIC_LIBS)
-		message("\n-> If you check LIGHT_STATIC_STD_LIBS, you also need to check SFML_STATIC_LIBRARIES.")
-		message("-> It would lead to multiple runtime environments which result in undefined behavior.\n")
-	elseif(WIN32 AND MSVC)
-		# Change all MSVC compiler flags to /MT
-		foreach(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE)
-			if(${flag} MATCHES "/MD")
-			string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-			endif()
-		endforeach()
-	elseif(CMAKE_COMPILER_IS_GNUCXX)
-		# Note: Doesn't work for TDM compiler, since it's compiling the runtime libs statically by default
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
-	endif()
+    if(NOT SFML_STATIC_LIBS)
+        message("\n-> If you check LIGHT_STATIC_STD_LIBS, you also need to check SFML_STATIC_LIBRARIES.")
+        message("-> It would lead to multiple runtime environments which result in undefined behavior.\n")
+    elseif(WIN32 AND MSVC)
+        # Change all MSVC compiler flags to /MT
+        foreach(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE)
+            if(${flag} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+            endif()
+        endforeach()
+    elseif(CMAKE_COMPILER_IS_GNUCXX)
+        # Note: Doesn't work for TDM compiler, since it's compiling the runtime libs statically by default
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
+    endif()
 endif()
 
 # Make sure that FindSFML.cmake searches for the static libraries
 if(SFML_STATIC_LIBS)
-	set(SFML_STATIC_LIBRARIES TRUE)
+    set(SFML_STATIC_LIBRARIES TRUE)
 endif()
 
 # Find OpenGL
@@ -51,11 +51,11 @@ find_package(SFML 2 REQUIRED COMPONENTS graphics window system)
 
 # Output an error if SFML wasn't found
 if(SFML_FOUND)
-	include_directories(${SFML_INCLUDE_DIR})
+    include_directories(${SFML_INCLUDE_DIR})
 else()
-	set(SFML_ROOT "" CACHE PATH "SFML top-level directory")
-	message("\n-> SFML directory not found. Set SFML_ROOT to SFML's top-level path (containing \"include\" and \"lib\" directories).")
-	message("-> Make sure the SFML libraries with the same configuration (Release/Debug, Static/Dynamic) exist.\n")
+    set(SFML_ROOT "" CACHE PATH "SFML top-level directory")
+    message("\n-> SFML directory not found. Set SFML_ROOT to SFML's top-level path (containing \"include\" and \"lib\" directories).")
+    message("-> Make sure the SFML libraries with the same configuration (Release/Debug, Static/Dynamic) exist.\n")
 endif()
 
 # Project

--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ Do an out of source build. Specifically:
 # Ubuntu
 To do an out of source build in Ubuntu, follow the steps below:
 
-    sudo apt-get install build-essential cmake libsdl2-dev libglew-dev
+    sudo apt-get install build-essential cmake libsfml-dev libglew-dev
     cd /path/to/source
     mkdir build && cd build
     cmake ..


### PR DESCRIPTION
In the Ubuntu section of the Compiling and Installing part of the README document, I accidentally added libsdl2-dev instead of libsfml-dev. I fixed that error in this commit by replacing libsdl2-dev with libsfml-dev.
